### PR TITLE
fix: 廃止ツールを allowed-tools から除去（現行 Claude Code 準拠）

### DIFF
--- a/.claude/commands/spec/design.md
+++ b/.claude/commands/spec/design.md
@@ -1,6 +1,6 @@
 ---
 description: Create comprehensive technical design for a specification
-allowed-tools: Bash, Glob, Grep, LS, Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+allowed-tools: Bash, Glob, Grep, Read, Write, Edit, WebSearch, WebFetch
 argument-hint: <feature-name> [-y]
 ---
 

--- a/.claude/commands/spec/impl.md
+++ b/.claude/commands/spec/impl.md
@@ -1,6 +1,6 @@
 ---
 description: Execute spec tasks using TDD methodology
-allowed-tools: Bash, Read, Write, Edit, MultiEdit, Grep, Glob, LS, WebFetch, WebSearch
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
 argument-hint: <feature-name> [task-numbers]
 ---
 

--- a/.claude/commands/spec/requirements.md
+++ b/.claude/commands/spec/requirements.md
@@ -1,6 +1,6 @@
 ---
 description: Generate comprehensive requirements for a specification
-allowed-tools: Bash, Glob, Grep, LS, Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+allowed-tools: Bash, Glob, Grep, Read, Write, Edit, WebSearch, WebFetch
 argument-hint: <feature-name>
 ---
 

--- a/.claude/commands/spec/status.md
+++ b/.claude/commands/spec/status.md
@@ -1,6 +1,6 @@
 ---
 description: Show specification status and progress
-allowed-tools: Bash, Read, Glob, Write, Edit, MultiEdit, Update
+allowed-tools: Bash, Read, Glob, Write, Edit
 argument-hint: <feature-name>
 ---
 

--- a/.claude/commands/spec/steering-custom.md
+++ b/.claude/commands/spec/steering-custom.md
@@ -1,6 +1,6 @@
 ---
 description: Create custom Spec-Driven Development steering documents for specialized project contexts
-allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # Spec-Driven Development Custom Steering Creation

--- a/.claude/commands/spec/steering.md
+++ b/.claude/commands/spec/steering.md
@@ -1,6 +1,6 @@
 ---
 description: Create or update Spec-Driven Development steering documents intelligently based on project state
-allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # Spec-Driven Development Steering Management

--- a/.claude/commands/spec/tasks.md
+++ b/.claude/commands/spec/tasks.md
@@ -1,6 +1,6 @@
 ---
 description: Generate implementation tasks for a specification
-allowed-tools: Read, Write, Edit, MultiEdit, Glob, Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
 argument-hint: <feature-name> [-y]
 ---
 

--- a/.claude/commands/spec/validate-gap.md
+++ b/.claude/commands/spec/validate-gap.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze implementation gap between requirements and existing codebase
-allowed-tools: Bash, Glob, Grep, Read, Write, Edit, MultiEdit, WebSearch, WebFetch
+allowed-tools: Bash, Glob, Grep, Read, Write, Edit, WebSearch, WebFetch
 argument-hint: <feature-name>
 ---
 

--- a/commands/design.md
+++ b/commands/design.md
@@ -1,6 +1,6 @@
 ---
 description: Create comprehensive technical design for a specification
-allowed-tools: Bash, Glob, Grep, LS, Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+allowed-tools: Bash, Glob, Grep, Read, Write, Edit, WebSearch, WebFetch
 argument-hint: <feature-name> [-y]
 ---
 

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -1,6 +1,6 @@
 ---
 description: Execute spec tasks using TDD methodology
-allowed-tools: Bash, Read, Write, Edit, MultiEdit, Grep, Glob, LS, WebFetch, WebSearch
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
 argument-hint: <feature-name> [task-numbers]
 ---
 

--- a/commands/requirements.md
+++ b/commands/requirements.md
@@ -1,6 +1,6 @@
 ---
 description: Generate comprehensive requirements for a specification
-allowed-tools: Bash, Glob, Grep, LS, Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+allowed-tools: Bash, Glob, Grep, Read, Write, Edit, WebSearch, WebFetch
 argument-hint: <feature-name>
 ---
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -1,6 +1,6 @@
 ---
 description: Show specification status and progress
-allowed-tools: Bash, Read, Glob, Write, Edit, MultiEdit, Update
+allowed-tools: Bash, Read, Glob, Write, Edit
 argument-hint: <feature-name>
 ---
 

--- a/commands/steering-custom.md
+++ b/commands/steering-custom.md
@@ -1,6 +1,6 @@
 ---
 description: Create custom Spec-Driven Development steering documents for specialized project contexts
-allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # Spec-Driven Development Custom Steering Creation

--- a/commands/steering.md
+++ b/commands/steering.md
@@ -1,6 +1,6 @@
 ---
 description: Create or update Spec-Driven Development steering documents intelligently based on project state
-allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # Spec-Driven Development Steering Management

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -1,6 +1,6 @@
 ---
 description: Generate implementation tasks for a specification
-allowed-tools: Read, Write, Edit, MultiEdit, Glob, Grep
+allowed-tools: Read, Write, Edit, Glob, Grep
 argument-hint: <feature-name> [-y]
 ---
 

--- a/commands/validate-gap.md
+++ b/commands/validate-gap.md
@@ -1,6 +1,6 @@
 ---
 description: Analyze implementation gap between requirements and existing codebase
-allowed-tools: Bash, Glob, Grep, Read, Write, Edit, MultiEdit, WebSearch, WebFetch
+allowed-tools: Bash, Glob, Grep, Read, Write, Edit, WebSearch, WebFetch
 argument-hint: <feature-name>
 ---
 


### PR DESCRIPTION
## 概要

各 slash command の frontmatter `allowed-tools` に、**現在の Claude Code に存在しないツール名**が残っていたため除去しました。

| ツール名 | 現状 | 対応 |
|---|---|---|
| `MultiEdit` | `Edit` に統合済み（複数置換は `replace_all` で代替） | 削除 |
| `LS` | 廃止 | 削除（`Glob` / `Read` / `Bash` で代替） |
| `Update` | そもそも存在しないツール名（誤記） | 削除 |

## 変更内容

- `commands/` と `.claude/commands/spec/` の両方の 8 コマンドを更新（計 16 ファイル）
- 変更は `allowed-tools` 行のみ。コマンド本文・ロジックには手を入れていません

## 影響

未知のツール名は Claude Code 側で無視されるため**動作上の挙動は変わりません**が、「`MultiEdit` を許可しているつもりで実際は無効」という stale な状態を解消します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)