### PR TITLE
feat: Claude Code プラグインとしてパッケージ化

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "plugins": [
+    {
+      "name": "spec",
+      "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
+      "version": "1.1.0",
+      "author": "kazgoto",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "spec",
+  "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
+  "version": "1.1.0",
+  "author": {
+    "name": "kazgoto"
+  },
+  "homepage": "https://github.com/kazgoto/claude-sdd",
+  "repository": "https://github.com/kazgoto/claude-sdd",
+  "license": "MIT"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Spec-Driven Development System will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-02
+
+### Added
+- **Claude Code plugin packaging** — install via `/plugin marketplace add kazgoto/claude-sdd` then `/plugin install spec@claude-sdd`
+  - `.claude-plugin/plugin.json` manifest (namespace `spec`, so commands remain `/spec:*`)
+  - `.claude-plugin/marketplace.json` for marketplace-based distribution (`source: "./"`)
+  - README install instructions (EN/JA)
+  - The existing `curl | bash` installer is kept for backward compatibility
+
+### Fixed
+- Removed obsolete tool names (`MultiEdit`, `LS`, `Update`) from each command's `allowed-tools` frontmatter to match current Claude Code
+
 ## [1.0.0] - 2026-01-08
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,9 +35,25 @@ Claude Spec-Driven Development (SDD) は、Claude Code CLI 専用に設計され
 
 ## インストール
 
-### リモートインストール（推奨）
+### プラグインとしてインストール（推奨）
 
-GitHubから直接インストール（クローン不要）:
+Claude Code のプラグイン機能で導入できます。一度マーケットプレイスを追加すれば、`/plugin install` で任意のプロジェクトから利用可能になります（バージョン管理・更新対応）。
+
+```bash
+# 1. マーケットプレイスを追加
+/plugin marketplace add kazgoto/claude-sdd
+
+# 2. プラグインをインストール
+/plugin install spec@claude-sdd
+```
+
+導入後は `/spec:init` などのコマンドがそのまま使えます（名前空間は `spec`）。
+
+> 仕様・ステアリングの保存先パスはプロジェクトルートの `.claude/spec-config.json` で指定します。存在しない場合は `.spec/` / `.spec-steering/` が既定値として使われます。
+
+### リモートインストール（スクリプト方式）
+
+プラグインを使わず、コマンド定義ファイルを直接配置する従来の方法です。GitHubから直接インストール（クローン不要）:
 
 ```bash
 # Bash (macOS, Linux, WSL2)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,23 @@ The system is configuration-driven, supporting flexible directory structures and
 
 ## Installation
 
-### Remote Installation (Recommended)
+### Install as a Plugin (Recommended)
+
+Install via Claude Code's plugin system. Add the marketplace once, then `/plugin install` makes the commands available in any project (with version management and updates).
+
+```bash
+# 1. Add the marketplace
+/plugin marketplace add kazgoto/claude-sdd
+
+# 2. Install the plugin
+/plugin install spec@claude-sdd
+```
+
+After installation, commands like `/spec:init` are available (namespace: `spec`).
+
+> Spec/steering output paths are configured via `.claude/spec-config.json` at the project root. If absent, `.spec/` and `.spec-steering/` are used as defaults.
+
+### Remote Installation (script-based)
 
 Install directly from GitHub without cloning:
 


### PR DESCRIPTION
## 概要

`claude-sdd` を **Claude Code プラグイン**として配信できるようにします。リポジトリ直下そのものを 1 プラグイン（名前空間 `spec`）として公開し、マーケットプレイス経由で導入・更新できます。

## 導入方法（このPRマージ後）

```bash
/plugin marketplace add kazgoto/claude-sdd
/plugin install spec@claude-sdd
```

→ `/spec:init` などがそのまま使えます（名前空間は `spec` なので既存の使い勝手を維持）。

## 変更内容

| ファイル | 内容 |
|---|---|
| `.claude-plugin/plugin.json` | プラグインマニフェスト（`name: spec`） |
| `.claude-plugin/marketplace.json` | マーケットプレイス定義（`source: "./"` = リポジトリ直下） |
| `README.md` / `README.ja.md` | `/plugin install` 手順を追記（従来の curl インストーラも残置） |
| `CHANGELOG.md` | `1.1.0` を追加 |

## 設計メモ

- **名前空間**: プラグイン名が名前空間プレフィックスになるため、`spec` とすることで `/spec:init` 等を完全に維持。
- **後方互換**: 既存の `curl | bash` インストーラはそのまま残し、プラグインを使わない導入も可能。
- **config**: コマンドは実行時にプロジェクトルートの `.claude/spec-config.json` を参照し、無ければ `.spec/` 既定にフォールバックするため、プラグイン導入だけで動作します。

## 補足

- このPRは #5（`allowed-tools` 修正）の上にスタックしています。base は `fix/allowed-tools-modernize`。#5 がマージ・削除されると自動的に `main` へ retarget されます。
- 既知の軽微点: `commands/README.md` がプラグインのコマンド走査で `/spec:readme` として拾われる可能性があります（curl インストーラでも既存の挙動）。別途整理可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)