### PR TITLE
fix: marketplace.json に必須フィールド name / owner を追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,8 @@
 {
-  "version": "1.0",
+  "name": "claude-sdd",
+  "owner": {
+    "name": "kazgoto"
+  },
   "plugins": [
     {
       "name": "spec",


### PR DESCRIPTION
## 問題

`/plugin marketplace add kazgoto/claude-sdd` がスキーマ検証で失敗していた。

```
Invalid schema: .claude-plugin/marketplace.json
  name: Invalid input: expected string, received undefined
  owner: Invalid input: expected object, received undefined
```

`marketplace.json` にマーケットプレイス定義として必須のトップレベル項目 `name` と `owner` が無いのが原因。add に失敗するためマーケットプレイスが登録されず、後続の `/plugin install spec@claude-sdd` も「マーケットプレイスが見つからない」で失敗していた。

## 修正

- トップレベルに `name: "claude-sdd"` を追加
- トップレベルに `owner: { "name": "kazgoto" }` を追加
- 不要なトップレベル `version` フィールドを削除

## 確認

マージ後、以下で導入できる:

```
/plugin marketplace add kazgoto/claude-sdd
/plugin install spec@claude-sdd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)