### PR TITLE
fix: marketplace.json の author をオブジェクト形式に修正

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,9 @@
       "name": "spec",
       "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
       "version": "1.1.0",
-      "author": "kazgoto",
+      "author": {
+        "name": "kazgoto"
+      },
       "source": "./"
     }
   ]


### PR DESCRIPTION
## 問題

`/plugin install spec@claude-sdd` が次のエラーで失敗していた:

```
Failed to install: This plugin uses a source type your Claude Code version
does not support. Update Claude Code and try again.
```

最新版（v2.1.160）でも発生し、原因は Claude Code のバージョンではなく `marketplace.json` のスキーマ違反。

plugin エントリの `author` を文字列 `"kazgoto"` で定義していたのが原因。[公式ドキュメント（Plugin marketplaces reference）](https://code.claude.com/docs/en/plugin-marketplaces.md)では `author` は **object 型**（`name` 必須・`email` 任意）と定義されており、文字列は非対応。公式 marketplace（anthropics/claude-plugins-official）の全エントリも object 形式を使用している。

`source: "./"` 自体は他の動作中プラグイン（例: genshijin）でも使われており問題ではなかった。

## 修正

```diff
-      "author": "kazgoto",
+      "author": {
+        "name": "kazgoto"
+      },
```

## 確認

マージ後、ローカルの marketplace キャッシュを更新してから再インストール:

```
/plugin marketplace update claude-sdd
/plugin install spec@claude-sdd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)