### PR TITLE
chore(release): bump version to 1.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "spec",
       "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "kazgoto"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec",
   "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "kazgoto"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the Spec-Driven Development System will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-23
+
+### Fixed
+- **`impl-parallel` workflow の起動時クラッシュ2点を修正** (#11)
+  - `agentType` を名前空間付き解決名にする（既定 `spec:` プレフィックス、`args.agentPrefix` で上書き可）。プラグイン同梱の spec-* エージェントはハーネスに名前空間付き（例 `spec:spec-implementer`）で登録されるため、バレ名のままだと `agent type not found` で落ちていた
+  - `args` を文字列 / JSON文字列 / オブジェクトのいずれでも受け付けるよう正規化。skill ランチャー経由の起動では `args` が feature 文字列で渡るため `args.feature` が undefined になり即落ちしていた
+
 ## [1.1.0] - 2026-06-02
 
 ### Added


### PR DESCRIPTION
## 概要

[#11](https://github.com/kazgoto/claude-sdd/pull/11)（`impl-parallel` workflow の起動時クラッシュ2点の修正）を**配布物（cache）へ反映させる**ための version bump。

## なぜ必要か

Claude Code のプラグインはバージョン単位で cache に展開される（`~/.claude/plugins/cache/claude-sdd/spec/<version>/`）。`#11` のソース修正は `main` に入ったが、`version` が `1.1.0` 据え置きのままだと、プラグイン更新をかけても同一バージョンの cache が再取得されず、古い（クラッシュする）ファイルが残り続ける。

`1.1.0 → 1.1.1` に上げることで、プラグイン更新時に cache (`1.1.1`) が新規取得され、fix が確実にローカルへ反映される。

## 変更

- `.claude-plugin/plugin.json`: `version` 1.1.0 → 1.1.1
- `.claude-plugin/marketplace.json`: `plugins[0].version` 1.1.0 → 1.1.1
- `CHANGELOG.md`: `[1.1.1]` エントリを追加（#11 の Fixed を記載）

## マージ後のローカル反映手順

1. `/plugin` でマーケットプレースを更新（`kazgoto/claude-sdd` を update）
2. プラグイン `spec@claude-sdd` を更新 → cache `1.1.1` が取得され fix 反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)