### PR TITLE
feat: /spec:status 全spec一覧モード + CLAUDE.md書き込みガード

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "spec",
       "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": {
         "name": "kazgoto"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec",
   "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": {
     "name": "kazgoto"
   },

--- a/.claude/commands/spec/complete.md
+++ b/.claude/commands/spec/complete.md
@@ -281,7 +281,19 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
     echo "[DRY RUN]   移動先: $TARGET_DIR" >&2
     echo "[DRY RUN]   対象ファイル:" >&2
     ls -1 "$SPEC_DIR" 2>/dev/null | sed 's/^/[DRY RUN]     /' >&2
-    echo "[DRY RUN] CLAUDE.mdからエントリを削除します" >&2
+    DRY_CLAUDE_MANAGED=false
+    if [ -f "CLAUDE.md" ]; then
+      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+        DRY_CLAUDE_MANAGED=true
+      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+        DRY_CLAUDE_MANAGED=true
+      fi
+    fi
+    if [ "$DRY_CLAUDE_MANAGED" = "true" ]; then
+      echo "[DRY RUN] CLAUDE.mdは保護されているため更新をスキップします" >&2
+    else
+      echo "[DRY RUN] CLAUDE.mdからエントリを削除します" >&2
+    fi
   else
     # Create _archived directory if needed
     if [ ! -d "$ARCHIVE_BASE" ]; then
@@ -322,10 +334,24 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
       printf '  - %s\n' "${MISSING_FILES[@]}" >&2
     fi
 
-    # Update CLAUDE.md
+    # Detect whether CLAUDE.md is protected/managed before touching it (e.g. an org-wide
+    # admin tool that regenerates it from a template, or a CI check that fails PRs which
+    # modify it) — writing to a managed file gets silently overwritten or actively blocks the PR.
+    CLAUDE_MANAGED=false
+    if [ -f "CLAUDE.md" ]; then
+      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+        CLAUDE_MANAGED=true
+      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+        CLAUDE_MANAGED=true
+      fi
+    fi
+
+    # Update CLAUDE.md (skip entirely if managed/protected)
     CLAUDE_FILE="CLAUDE.md"
 
-    if [ ! -f "$CLAUDE_FILE" ]; then
+    if [ "$CLAUDE_MANAGED" = "true" ]; then
+      echo "ℹ️  CLAUDE.mdは保護されているため更新をスキップしました。進行中の仕様一覧は /spec:status（引数なし）で確認できます。" >&2
+    elif [ ! -f "$CLAUDE_FILE" ]; then
       echo "⚠️  警告: CLAUDE.mdが見つかりません。エントリ削除をスキップします。" >&2
     elif ! grep -q "$FEATURE_NAME" "$CLAUDE_FILE"; then
       echo "⚠️  警告: CLAUDE.mdに仕様のエントリが見つかりません: $FEATURE_NAME" >&2

--- a/.claude/commands/spec/init-issue.md
+++ b/.claude/commands/spec/init-issue.md
@@ -196,12 +196,25 @@ Specification initialized from GitHub Issue. Next step: Generate requirements.
 - `$SPECS_DIR[feature-name]/session-state.md`
 ```
 
-### 8. Update CLAUDE.md Reference
-
-Add the new spec to the active specifications list with:
-- Feature name
-- GitHub Issue reference (#123)
-- Brief description from issue title
+### 8. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
+Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
+(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
+which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
+```bash
+CLAUDE_MANAGED=false
+if [ -f "CLAUDE.md" ]; then
+  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  fi
+fi
+```
+- **If `CLAUDE_MANAGED=false`**: add the new spec to the active specifications list with:
+  - Feature name
+  - GitHub Issue reference (#123)
+  - Brief description from issue title
+- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
 
 ### 9. Link Issue to Specification (Optional)
 

--- a/.claude/commands/spec/init.md
+++ b/.claude/commands/spec/init.md
@@ -145,8 +145,22 @@ Specification initialized. Next step: Generate requirements document.
 - `$SPECS_DIR[generated-feature-name]/session-state.md`
 ```
 
-### 6. Update CLAUDE.md Reference
-Add the new spec to the active specifications list with the generated feature name and a brief description.
+### 6. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
+Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
+(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
+which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
+```bash
+CLAUDE_MANAGED=false
+if [ -f "CLAUDE.md" ]; then
+  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  fi
+fi
+```
+- **If `CLAUDE_MANAGED=false`**: add the new spec to CLAUDE.md's active specifications list with the generated feature name and a brief description (unchanged behavior).
+- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
 
 ## Next Steps After Initialization
 

--- a/.claude/commands/spec/status.md
+++ b/.claude/commands/spec/status.md
@@ -1,7 +1,7 @@
 ---
 description: Show specification status and progress
 allowed-tools: Bash, Read, Glob, Write, Edit
-argument-hint: <feature-name>
+argument-hint: [feature-name]
 ---
 
 # Specification Status
@@ -35,6 +35,48 @@ echo "STEERING_DIR=$STEERING_DIR"
 ```
 
 Store the resolved paths as variables: `$SPECS_DIR` and `$STEERING_DIR` for use in subsequent steps.
+
+---
+
+## Argument Handling
+
+- **If `$1` is provided**: proceed to "Spec Context" below for a single-feature report (unchanged behavior).
+- **If `$1` is empty/not provided**: run "All Specs Overview" instead, then STOP — do not generate a single-feature report.
+
+## All Specs Overview (when `$1` is not provided)
+
+This is a pure read-time aggregation over `spec.json` files — **no file is written**, so it can
+never go stale and never conflicts with any repo's file-protection rules (e.g. an admin-managed
+`CLAUDE.md` that a CI check reverts/blocks edits to). This is the recommended way to see "what's
+in progress across this repo" — do not resurrect any pattern that writes an active-specs list into
+`CLAUDE.md` or any other file outside `$SPECS_DIR`.
+
+Use the Bash tool to enumerate specs (skip anything under `${SPECS_DIR}_archived/`):
+```bash
+for f in "$SPECS_DIR"*/spec.json; do
+  [ -f "$f" ] && echo "$f"
+done
+```
+
+For each `spec.json` found:
+1. Read `feature_name`, `phase`, `updated_at`, `source.type`/`source.issue_number` (if present),
+   and `approvals.*.approved` for requirements/design/tasks.
+2. If a sibling `session-state.md` exists in the same directory, read its FrontMatter
+   `currentTaskIndex`/`totalTasks` to compute a task-completion fraction (e.g. `4/4`).
+3. Render one row per spec, **sorted by `updated_at` descending** (most recently touched first):
+
+```markdown
+## 進行中の Spec 一覧
+
+| Feature | Phase | 承認 (req/design/tasks) | 進捗 | 更新日時 | Issue |
+|---|---|---|---|---|---|
+| 307-anomaly-alert-dashboard | implementation | ✅/✅/✅ | 4/4 (100%) | 2026-06-30 | #307 |
+| 118-dashboard-date-format-unification | tasks-generated | ✅/✅/⬜ | — | 2026-06-25 | #118 |
+```
+
+- Also report the count of specs under `${SPECS_DIR}_archived/` as a one-line summary
+  (e.g. "完了済み: 13件（`_archived/` 参照）") — list the directory count only, not each one.
+- If zero specs exist under `$SPECS_DIR` (excluding `_archived/`): print "進行中の spec はありません。"
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Spec-Driven Development System will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-07-01
+
+### Added
+- **`/spec:status`**: 引数無しで実行すると、`$SPECS_DIR` 配下の全specの状態（phase・承認状況・タスク進捗・更新日時・Issue番号）を一覧表示するモードを追加。spec.json/session-state.mdの読み取りのみで、ファイル書き込みは一切行わない（陳腐化しない・他ツールと競合しない）。
+
+### Fixed
+- **`/spec:init` / `/spec:init-issue` / `/spec:complete`**: CLAUDE.md への「進行中の仕様一覧」の追記・削除が、外部ツールが自動生成・管理するCLAUDE.mdや、CLAUDE.mdの変更を検知してPRを failさせるCIチェックと衝突する問題を修正。CLAUDE.mdが保護/管理下にあるかを検出（バナー文言 or ワークフローでの参照）し、該当する場合は書き込みをスキップして代わりに `/spec:status`（引数無し）を案内する。管理下でないリポジトリでは従来通りCLAUDE.mdへ追記する。
+
 ## [1.1.2] - 2026-07-01
 
 ### Added

--- a/commands/complete.md
+++ b/commands/complete.md
@@ -281,7 +281,19 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
     echo "[DRY RUN]   移動先: $TARGET_DIR" >&2
     echo "[DRY RUN]   対象ファイル:" >&2
     ls -1 "$SPEC_DIR" 2>/dev/null | sed 's/^/[DRY RUN]     /' >&2
-    echo "[DRY RUN] CLAUDE.mdからエントリを削除します" >&2
+    DRY_CLAUDE_MANAGED=false
+    if [ -f "CLAUDE.md" ]; then
+      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+        DRY_CLAUDE_MANAGED=true
+      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+        DRY_CLAUDE_MANAGED=true
+      fi
+    fi
+    if [ "$DRY_CLAUDE_MANAGED" = "true" ]; then
+      echo "[DRY RUN] CLAUDE.mdは保護されているため更新をスキップします" >&2
+    else
+      echo "[DRY RUN] CLAUDE.mdからエントリを削除します" >&2
+    fi
   else
     # Create _archived directory if needed
     if [ ! -d "$ARCHIVE_BASE" ]; then
@@ -322,10 +334,24 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
       printf '  - %s\n' "${MISSING_FILES[@]}" >&2
     fi
 
-    # Update CLAUDE.md
+    # Detect whether CLAUDE.md is protected/managed before touching it (e.g. an org-wide
+    # admin tool that regenerates it from a template, or a CI check that fails PRs which
+    # modify it) — writing to a managed file gets silently overwritten or actively blocks the PR.
+    CLAUDE_MANAGED=false
+    if [ -f "CLAUDE.md" ]; then
+      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+        CLAUDE_MANAGED=true
+      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+        CLAUDE_MANAGED=true
+      fi
+    fi
+
+    # Update CLAUDE.md (skip entirely if managed/protected)
     CLAUDE_FILE="CLAUDE.md"
 
-    if [ ! -f "$CLAUDE_FILE" ]; then
+    if [ "$CLAUDE_MANAGED" = "true" ]; then
+      echo "ℹ️  CLAUDE.mdは保護されているため更新をスキップしました。進行中の仕様一覧は /spec:status（引数なし）で確認できます。" >&2
+    elif [ ! -f "$CLAUDE_FILE" ]; then
       echo "⚠️  警告: CLAUDE.mdが見つかりません。エントリ削除をスキップします。" >&2
     elif ! grep -q "$FEATURE_NAME" "$CLAUDE_FILE"; then
       echo "⚠️  警告: CLAUDE.mdに仕様のエントリが見つかりません: $FEATURE_NAME" >&2

--- a/commands/init-issue.md
+++ b/commands/init-issue.md
@@ -196,12 +196,25 @@ Specification initialized from GitHub Issue. Next step: Generate requirements.
 - `$SPECS_DIR[feature-name]/session-state.md`
 ```
 
-### 8. Update CLAUDE.md Reference
-
-Add the new spec to the active specifications list with:
-- Feature name
-- GitHub Issue reference (#123)
-- Brief description from issue title
+### 8. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
+Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
+(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
+which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
+```bash
+CLAUDE_MANAGED=false
+if [ -f "CLAUDE.md" ]; then
+  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  fi
+fi
+```
+- **If `CLAUDE_MANAGED=false`**: add the new spec to the active specifications list with:
+  - Feature name
+  - GitHub Issue reference (#123)
+  - Brief description from issue title
+- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
 
 ### 9. Link Issue to Specification (Optional)
 

--- a/commands/init.md
+++ b/commands/init.md
@@ -145,8 +145,22 @@ Specification initialized. Next step: Generate requirements document.
 - `$SPECS_DIR[generated-feature-name]/session-state.md`
 ```
 
-### 6. Update CLAUDE.md Reference
-Add the new spec to the active specifications list with the generated feature name and a brief description.
+### 6. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
+Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
+(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
+which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
+```bash
+CLAUDE_MANAGED=false
+if [ -f "CLAUDE.md" ]; then
+  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
+    CLAUDE_MANAGED=true
+  fi
+fi
+```
+- **If `CLAUDE_MANAGED=false`**: add the new spec to CLAUDE.md's active specifications list with the generated feature name and a brief description (unchanged behavior).
+- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
 
 ## Next Steps After Initialization
 

--- a/commands/status.md
+++ b/commands/status.md
@@ -1,7 +1,7 @@
 ---
 description: Show specification status and progress
 allowed-tools: Bash, Read, Glob, Write, Edit
-argument-hint: <feature-name>
+argument-hint: [feature-name]
 ---
 
 # Specification Status
@@ -35,6 +35,48 @@ echo "STEERING_DIR=$STEERING_DIR"
 ```
 
 Store the resolved paths as variables: `$SPECS_DIR` and `$STEERING_DIR` for use in subsequent steps.
+
+---
+
+## Argument Handling
+
+- **If `$1` is provided**: proceed to "Spec Context" below for a single-feature report (unchanged behavior).
+- **If `$1` is empty/not provided**: run "All Specs Overview" instead, then STOP — do not generate a single-feature report.
+
+## All Specs Overview (when `$1` is not provided)
+
+This is a pure read-time aggregation over `spec.json` files — **no file is written**, so it can
+never go stale and never conflicts with any repo's file-protection rules (e.g. an admin-managed
+`CLAUDE.md` that a CI check reverts/blocks edits to). This is the recommended way to see "what's
+in progress across this repo" — do not resurrect any pattern that writes an active-specs list into
+`CLAUDE.md` or any other file outside `$SPECS_DIR`.
+
+Use the Bash tool to enumerate specs (skip anything under `${SPECS_DIR}_archived/`):
+```bash
+for f in "$SPECS_DIR"*/spec.json; do
+  [ -f "$f" ] && echo "$f"
+done
+```
+
+For each `spec.json` found:
+1. Read `feature_name`, `phase`, `updated_at`, `source.type`/`source.issue_number` (if present),
+   and `approvals.*.approved` for requirements/design/tasks.
+2. If a sibling `session-state.md` exists in the same directory, read its FrontMatter
+   `currentTaskIndex`/`totalTasks` to compute a task-completion fraction (e.g. `4/4`).
+3. Render one row per spec, **sorted by `updated_at` descending** (most recently touched first):
+
+```markdown
+## 進行中の Spec 一覧
+
+| Feature | Phase | 承認 (req/design/tasks) | 進捗 | 更新日時 | Issue |
+|---|---|---|---|---|---|
+| 307-anomaly-alert-dashboard | implementation | ✅/✅/✅ | 4/4 (100%) | 2026-06-30 | #307 |
+| 118-dashboard-date-format-unification | tasks-generated | ✅/✅/⬜ | — | 2026-06-25 | #118 |
+```
+
+- Also report the count of specs under `${SPECS_DIR}_archived/` as a one-line summary
+  (e.g. "完了済み: 13件（`_archived/` 参照）") — list the directory count only, not each one.
+- If zero specs exist under `$SPECS_DIR` (excluding `_archived/`): print "進行中の spec はありません。"
 
 ---
 


### PR DESCRIPTION
## Summary
- `/spec:status`（引数無し）で `$SPECS_DIR` 配下の全specを一覧表示するモードを追加。読み取りのみで書き込みは一切しないため陳腐化しない
- `/spec:init` / `/spec:init-issue` / `/spec:complete` の CLAUDE.md 追記・削除処理に、保護/管理下検出ガードを追加。管理下なら書き込みをスキップし `/spec:status` を案内する

## Background
CLAUDE.md を外部ツール（org管理のadmin repo等）が自動生成・管理しているリポジトリでは、`/spec:init`系のCLAUDE.md追記が (a) 次回の自動生成で上書きされる (b) CLAUDE.mdの変更を検知してPRをfailさせるCIチェックがある、のどちらか（あるいは両方）と衝突し、構造的に機能しない。読み取りのみで完結する `/spec:status` の一覧モードに置き換え、書き込み系コマンドは検出して自動スキップするようにした。

## Test plan
- [ ] CLAUDE.mdが保護されていないリポジトリで `/spec:init` 等を実行し、従来通りCLAUDE.mdへ追記されることを確認（後方互換）
- [ ] CLAUDE.mdが保護されているリポジトリ（バナー文言 or protect-managed-files的なワークフローあり）で `/spec:init`/`/spec:complete` を実行し、CLAUDE.mdへの書き込みがスキップされ `/spec:status` の案内が出ることを確認
- [ ] `/spec:status`（引数無し）で複数specがphase・進捗・Issue番号付きで一覧表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)