### PR TITLE
feat!: CLAUDE.md 連携を全面的に廃止 (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "spec",
       "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "author": {
         "name": "kazgoto"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec",
   "description": "Spec-Driven Development workflow for Claude Code — 仕様 → 設計 → タスク → TDD 実装 を段階的に進める /spec: コマンド群",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "author": {
     "name": "kazgoto"
   },

--- a/.claude/commands/spec/complete.md
+++ b/.claude/commands/spec/complete.md
@@ -6,7 +6,7 @@ argument-hint: <feature-name> [--pr PR_NUMBER] [--skip-archive] [--dry-run]
 
 # Spec Complete Command
 
-仕様完了時のアーカイブ処理を自動化し、spec.jsonの更新、ディレクトリのアーカイブ、CLAUDE.mdの更新を一括で実行する。
+仕様完了時のアーカイブ処理を自動化し、spec.jsonの更新とディレクトリのアーカイブを一括で実行する。
 
 ## Path Resolution
 
@@ -281,19 +281,6 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
     echo "[DRY RUN]   移動先: $TARGET_DIR" >&2
     echo "[DRY RUN]   対象ファイル:" >&2
     ls -1 "$SPEC_DIR" 2>/dev/null | sed 's/^/[DRY RUN]     /' >&2
-    DRY_CLAUDE_MANAGED=false
-    if [ -f "CLAUDE.md" ]; then
-      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-        DRY_CLAUDE_MANAGED=true
-      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-        DRY_CLAUDE_MANAGED=true
-      fi
-    fi
-    if [ "$DRY_CLAUDE_MANAGED" = "true" ]; then
-      echo "[DRY RUN] CLAUDE.mdは保護されているため更新をスキップします" >&2
-    else
-      echo "[DRY RUN] CLAUDE.mdからエントリを削除します" >&2
-    fi
   else
     # Create _archived directory if needed
     if [ ! -d "$ARCHIVE_BASE" ]; then
@@ -333,52 +320,6 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
       echo "⚠️  警告: 以下のファイルが見つかりません:" >&2
       printf '  - %s\n' "${MISSING_FILES[@]}" >&2
     fi
-
-    # Detect whether CLAUDE.md is protected/managed before touching it (e.g. an org-wide
-    # admin tool that regenerates it from a template, or a CI check that fails PRs which
-    # modify it) — writing to a managed file gets silently overwritten or actively blocks the PR.
-    CLAUDE_MANAGED=false
-    if [ -f "CLAUDE.md" ]; then
-      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-        CLAUDE_MANAGED=true
-      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-        CLAUDE_MANAGED=true
-      fi
-    fi
-
-    # Update CLAUDE.md (skip entirely if managed/protected)
-    CLAUDE_FILE="CLAUDE.md"
-
-    if [ "$CLAUDE_MANAGED" = "true" ]; then
-      echo "ℹ️  CLAUDE.mdは保護されているため更新をスキップしました。進行中の仕様一覧は /spec:status（引数なし）で確認できます。" >&2
-    elif [ ! -f "$CLAUDE_FILE" ]; then
-      echo "⚠️  警告: CLAUDE.mdが見つかりません。エントリ削除をスキップします。" >&2
-    elif ! grep -q "$FEATURE_NAME" "$CLAUDE_FILE"; then
-      echo "⚠️  警告: CLAUDE.mdに仕様のエントリが見つかりません: $FEATURE_NAME" >&2
-    else
-      # Remove entry from CLAUDE.md
-      TEMP_FILE=$(mktemp)
-
-      awk -v name="$FEATURE_NAME" '
-        BEGIN { skip = 0 }
-        /^###/ {
-          if (skip) { skip = 0 }
-          if ($0 ~ name) { skip = 1; next }
-        }
-        !skip { print }
-      ' "$CLAUDE_FILE" > "$TEMP_FILE"
-
-      if [ $? -eq 0 ]; then
-        mv "$TEMP_FILE" "$CLAUDE_FILE"
-        if [ $? -ne 0 ]; then
-          echo "⚠️  警告: CLAUDE.mdの書き込みに失敗しました" >&2
-          rm -f "$TEMP_FILE"
-        fi
-      else
-        echo "⚠️  警告: CLAUDE.mdの更新に失敗しました" >&2
-        rm -f "$TEMP_FILE"
-      fi
-    fi
   fi
 fi
 ```
@@ -411,7 +352,6 @@ EOF
 
 if [ "$SKIP_ARCHIVE" -eq 0 ]; then
   echo "  - ディレクトリ移動: $FEATURE_NAME -> _archived/$FEATURE_NAME"
-  echo "  - CLAUDE.md"
 fi
 
 cat << EOF
@@ -429,7 +369,6 @@ cat << EOF
 
   - Update spec.json with completion metadata
   - Archive spec to _archived/$FEATURE_NAME
-  - Remove entry from CLAUDE.md
 
 EOF
 ```
@@ -455,6 +394,6 @@ EOF
 The command implements fail-fast for core operations and graceful degradation for auxiliary operations:
 
 - **Fail-fast**: Missing spec, invalid PR, archive conflicts
-- **Graceful**: Missing CLAUDE.md, CLAUDE.md update failures
+- **Graceful**: Missing expected files in the archived spec directory
 
 All errors are output to stderr with actionable guidance.

--- a/.claude/commands/spec/init-issue.md
+++ b/.claude/commands/spec/init-issue.md
@@ -196,27 +196,7 @@ Specification initialized from GitHub Issue. Next step: Generate requirements.
 - `$SPECS_DIR[feature-name]/session-state.md`
 ```
 
-### 8. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
-Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
-(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
-which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
-```bash
-CLAUDE_MANAGED=false
-if [ -f "CLAUDE.md" ]; then
-  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  fi
-fi
-```
-- **If `CLAUDE_MANAGED=false`**: add the new spec to the active specifications list with:
-  - Feature name
-  - GitHub Issue reference (#123)
-  - Brief description from issue title
-- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
-
-### 9. Link Issue to Specification (Optional)
+### 8. Link Issue to Specification (Optional)
 
 If issue is still open, add a comment linking to the spec:
 ```bash

--- a/.claude/commands/spec/init.md
+++ b/.claude/commands/spec/init.md
@@ -145,23 +145,6 @@ Specification initialized. Next step: Generate requirements document.
 - `$SPECS_DIR[generated-feature-name]/session-state.md`
 ```
 
-### 6. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
-Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
-(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
-which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
-```bash
-CLAUDE_MANAGED=false
-if [ -f "CLAUDE.md" ]; then
-  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  fi
-fi
-```
-- **If `CLAUDE_MANAGED=false`**: add the new spec to CLAUDE.md's active specifications list with the generated feature name and a brief description (unchanged behavior).
-- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
-
 ## Next Steps After Initialization
 
 Follow the strict spec-driven development workflow:

--- a/.claude/commands/spec/status.md
+++ b/.claude/commands/spec/status.md
@@ -46,10 +46,9 @@ Store the resolved paths as variables: `$SPECS_DIR` and `$STEERING_DIR` for use 
 ## All Specs Overview (when `$1` is not provided)
 
 This is a pure read-time aggregation over `spec.json` files — **no file is written**, so it can
-never go stale and never conflicts with any repo's file-protection rules (e.g. an admin-managed
-`CLAUDE.md` that a CI check reverts/blocks edits to). This is the recommended way to see "what's
-in progress across this repo" — do not resurrect any pattern that writes an active-specs list into
-`CLAUDE.md` or any other file outside `$SPECS_DIR`.
+never go stale and never conflicts with any repo's file-protection rules. This is the single,
+recommended way to see "what's in progress across this repo" — do not resurrect any pattern that
+writes an active-specs list into any file outside `$SPECS_DIR`.
 
 Use the Bash tool to enumerate specs (skip anything under `${SPECS_DIR}_archived/`):
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Spec-Driven Development System will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-08-25
+
+### Removed
+- **CLAUDE.md 連携を全面的に廃止**。`/spec:init` / `/spec:init-issue` / `/spec:complete` / `/spec:status` から、CLAUDE.md への「進行中の仕様一覧」の追記・削除、および 1.1.3 で入れた保護判定（`CLAUDE_MANAGED` の検出ロジック）とその報告メッセージをすべて削除した。
+  - `/spec:init`: 「6. Update CLAUDE.md Reference」節を削除
+  - `/spec:init-issue`: 「8. Update CLAUDE.md Reference」節を削除（以降の節番号を繰り上げ）
+  - `/spec:complete`: 保護判定・エントリ削除処理・dry-run 表示・完了サマリーの変更ファイル一覧・推奨コミットメッセージ・Error Handling から CLAUDE.md の記述を削除
+  - `/spec:status`: 説明文から CLAUDE.md への言及を削除（`$SPECS_DIR` 外へ書き出さないという方針自体は維持）
+  - README.md / docs/migration-guide.md の該当記述も削除。README.md の `/spec:steering-custom` にあった「CLAUDE.md に登録する」という記述は、コマンド側に実体が無い古い記述だったため併せて削除
+  - 代替機能は追加していない。進行中の仕様一覧は従来どおり `/spec:status`（引数なし）に一本化する
+  - 背景: 1.1.3 の保護判定は「書き込みをスキップした」旨の報告が実行のたびに出るため、外部ツールが CLAUDE.md を管理しているリポジトリでは毎回ノイズになっていた。判定を賢くするのではなく連携自体を外す方針とした
+
+### Fixed
+- `.claude-plugin/marketplace.json` の version が 1.1.4 のまま plugin.json（1.1.5）と乖離していたのを解消し、両者を 1.2.0 に揃えた
+
 ## [1.1.4] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ Initialize a new specification from a project description.
    - `spec.json` - Metadata and approval tracking
    - `requirements.md` - Lightweight template with project description
    - `session-state.md` - Initial session state
-4. Updates CLAUDE.md Active Specifications section (if exists)
 
 **Example output:**
 ```
@@ -485,7 +484,6 @@ Create custom steering documents for specialized contexts.
    - Target context (specific files, features, or always-on)
    - Content structure
 3. Creates specialized steering document
-4. Registers it in CLAUDE.md custom steering section
 
 **Example output:**
 ```
@@ -493,7 +491,6 @@ Create custom steering documents for specialized contexts.
 📁 Location: .spec-steering/api-design-guidelines.md
 
 Inclusion mode: Conditional (*.api.ts files)
-Registered in: CLAUDE.md
 
 📖 This steering will be loaded when working on API files
 ```
@@ -635,9 +632,7 @@ Mark specification as complete, update metadata, and archive.
 4. Archives specification (unless `--skip-archive`):
    - Moves directory to `{SPECS_DIR}_archived/{feature-name}/`
    - Verifies all expected files present
-5. Updates CLAUDE.md:
-   - Removes entry from Active Specifications section
-6. Displays completion summary with recommended commit message
+5. Displays completion summary with recommended commit message
 
 **Example output:**
 ```
@@ -651,7 +646,6 @@ Mark specification as complete, update metadata, and archive.
 📝 変更されたファイル:
   - spec.json
   - ディレクトリ移動: user-authentication -> _archived/user-authentication
-  - CLAUDE.md
 
 🔄 次のステップ:
   1. 変更を確認してください

--- a/commands/complete.md
+++ b/commands/complete.md
@@ -6,7 +6,7 @@ argument-hint: <feature-name> [--pr PR_NUMBER] [--skip-archive] [--dry-run]
 
 # Spec Complete Command
 
-仕様完了時のアーカイブ処理を自動化し、spec.jsonの更新、ディレクトリのアーカイブ、CLAUDE.mdの更新を一括で実行する。
+仕様完了時のアーカイブ処理を自動化し、spec.jsonの更新とディレクトリのアーカイブを一括で実行する。
 
 ## Path Resolution
 
@@ -281,19 +281,6 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
     echo "[DRY RUN]   移動先: $TARGET_DIR" >&2
     echo "[DRY RUN]   対象ファイル:" >&2
     ls -1 "$SPEC_DIR" 2>/dev/null | sed 's/^/[DRY RUN]     /' >&2
-    DRY_CLAUDE_MANAGED=false
-    if [ -f "CLAUDE.md" ]; then
-      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-        DRY_CLAUDE_MANAGED=true
-      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-        DRY_CLAUDE_MANAGED=true
-      fi
-    fi
-    if [ "$DRY_CLAUDE_MANAGED" = "true" ]; then
-      echo "[DRY RUN] CLAUDE.mdは保護されているため更新をスキップします" >&2
-    else
-      echo "[DRY RUN] CLAUDE.mdからエントリを削除します" >&2
-    fi
   else
     # Create _archived directory if needed
     if [ ! -d "$ARCHIVE_BASE" ]; then
@@ -333,52 +320,6 @@ if [ "$SKIP_ARCHIVE" -eq 0 ]; then
       echo "⚠️  警告: 以下のファイルが見つかりません:" >&2
       printf '  - %s\n' "${MISSING_FILES[@]}" >&2
     fi
-
-    # Detect whether CLAUDE.md is protected/managed before touching it (e.g. an org-wide
-    # admin tool that regenerates it from a template, or a CI check that fails PRs which
-    # modify it) — writing to a managed file gets silently overwritten or actively blocks the PR.
-    CLAUDE_MANAGED=false
-    if [ -f "CLAUDE.md" ]; then
-      if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-        CLAUDE_MANAGED=true
-      elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-        CLAUDE_MANAGED=true
-      fi
-    fi
-
-    # Update CLAUDE.md (skip entirely if managed/protected)
-    CLAUDE_FILE="CLAUDE.md"
-
-    if [ "$CLAUDE_MANAGED" = "true" ]; then
-      echo "ℹ️  CLAUDE.mdは保護されているため更新をスキップしました。進行中の仕様一覧は /spec:status（引数なし）で確認できます。" >&2
-    elif [ ! -f "$CLAUDE_FILE" ]; then
-      echo "⚠️  警告: CLAUDE.mdが見つかりません。エントリ削除をスキップします。" >&2
-    elif ! grep -q "$FEATURE_NAME" "$CLAUDE_FILE"; then
-      echo "⚠️  警告: CLAUDE.mdに仕様のエントリが見つかりません: $FEATURE_NAME" >&2
-    else
-      # Remove entry from CLAUDE.md
-      TEMP_FILE=$(mktemp)
-
-      awk -v name="$FEATURE_NAME" '
-        BEGIN { skip = 0 }
-        /^###/ {
-          if (skip) { skip = 0 }
-          if ($0 ~ name) { skip = 1; next }
-        }
-        !skip { print }
-      ' "$CLAUDE_FILE" > "$TEMP_FILE"
-
-      if [ $? -eq 0 ]; then
-        mv "$TEMP_FILE" "$CLAUDE_FILE"
-        if [ $? -ne 0 ]; then
-          echo "⚠️  警告: CLAUDE.mdの書き込みに失敗しました" >&2
-          rm -f "$TEMP_FILE"
-        fi
-      else
-        echo "⚠️  警告: CLAUDE.mdの更新に失敗しました" >&2
-        rm -f "$TEMP_FILE"
-      fi
-    fi
   fi
 fi
 ```
@@ -411,7 +352,6 @@ EOF
 
 if [ "$SKIP_ARCHIVE" -eq 0 ]; then
   echo "  - ディレクトリ移動: $FEATURE_NAME -> _archived/$FEATURE_NAME"
-  echo "  - CLAUDE.md"
 fi
 
 cat << EOF
@@ -429,7 +369,6 @@ cat << EOF
 
   - Update spec.json with completion metadata
   - Archive spec to _archived/$FEATURE_NAME
-  - Remove entry from CLAUDE.md
 
 EOF
 ```
@@ -455,6 +394,6 @@ EOF
 The command implements fail-fast for core operations and graceful degradation for auxiliary operations:
 
 - **Fail-fast**: Missing spec, invalid PR, archive conflicts
-- **Graceful**: Missing CLAUDE.md, CLAUDE.md update failures
+- **Graceful**: Missing expected files in the archived spec directory
 
 All errors are output to stderr with actionable guidance.

--- a/commands/init-issue.md
+++ b/commands/init-issue.md
@@ -196,27 +196,7 @@ Specification initialized from GitHub Issue. Next step: Generate requirements.
 - `$SPECS_DIR[feature-name]/session-state.md`
 ```
 
-### 8. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
-Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
-(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
-which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
-```bash
-CLAUDE_MANAGED=false
-if [ -f "CLAUDE.md" ]; then
-  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  fi
-fi
-```
-- **If `CLAUDE_MANAGED=false`**: add the new spec to the active specifications list with:
-  - Feature name
-  - GitHub Issue reference (#123)
-  - Brief description from issue title
-- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
-
-### 9. Link Issue to Specification (Optional)
+### 8. Link Issue to Specification (Optional)
 
 If issue is still open, add a comment linking to the spec:
 ```bash

--- a/commands/init.md
+++ b/commands/init.md
@@ -145,23 +145,6 @@ Specification initialized. Next step: Generate requirements document.
 - `$SPECS_DIR[generated-feature-name]/session-state.md`
 ```
 
-### 6. Update CLAUDE.md Reference (skip if CLAUDE.md is protected/managed)
-Before writing anything, detect whether `CLAUDE.md` is protected/managed by an external system
-(e.g. an org-wide admin tool that regenerates it from a template, or a CI check that fails PRs
-which modify it) — writing to a managed file gets silently overwritten or actively blocks the PR:
-```bash
-CLAUDE_MANAGED=false
-if [ -f "CLAUDE.md" ]; then
-  if grep -qiE "auto.?generated|automatically generated|自動生成|managed by|管理されています|do not edit|直接編集" CLAUDE.md 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  elif grep -rlq "CLAUDE\.md" .github/workflows/ 2>/dev/null; then
-    CLAUDE_MANAGED=true
-  fi
-fi
-```
-- **If `CLAUDE_MANAGED=false`**: add the new spec to CLAUDE.md's active specifications list with the generated feature name and a brief description (unchanged behavior).
-- **If `CLAUDE_MANAGED=true`**: do NOT write to CLAUDE.md. Tell the user instead: "このリポジトリの CLAUDE.md は保護されているため追記しません。進行中の仕様一覧は `/spec:status`（引数なし）で確認できます。"
-
 ## Next Steps After Initialization
 
 Follow the strict spec-driven development workflow:

--- a/commands/status.md
+++ b/commands/status.md
@@ -46,10 +46,9 @@ Store the resolved paths as variables: `$SPECS_DIR` and `$STEERING_DIR` for use 
 ## All Specs Overview (when `$1` is not provided)
 
 This is a pure read-time aggregation over `spec.json` files — **no file is written**, so it can
-never go stale and never conflicts with any repo's file-protection rules (e.g. an admin-managed
-`CLAUDE.md` that a CI check reverts/blocks edits to). This is the recommended way to see "what's
-in progress across this repo" — do not resurrect any pattern that writes an active-specs list into
-`CLAUDE.md` or any other file outside `$SPECS_DIR`.
+never go stale and never conflicts with any repo's file-protection rules. This is the single,
+recommended way to see "what's in progress across this repo" — do not resurrect any pattern that
+writes an active-specs list into any file outside `$SPECS_DIR`.
 
 Use the Bash tool to enumerate specs (skip anything under `${SPECS_DIR}_archived/`):
 ```bash

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -204,32 +204,7 @@ ls .kiro/specs/
 /spec:init Test migration in compatibility mode
 ```
 
-#### Step 4: Update CLAUDE.md (Optional)
-
-Simplify your project's CLAUDE.md by removing detailed workflow definitions:
-
-**Before**:
-```markdown
-## Workflow
-
-### Phase 1: Specification Creation
-1. `/spec:init [detailed description]` - Initialize spec with detailed project description
-2. `/spec:requirements [feature]` - Generate requirements document
-... (50+ lines of detailed workflow)
-```
-
-**After**:
-```markdown
-## Workflow
-
-See [.claude/commands/spec/README.md](.claude/commands/spec/README.md) for complete workflow documentation.
-
-### Active Specifications
-- Check `.kiro/specs/` for active specifications
-- Use `/spec:status [feature-name]` to check progress
-```
-
-#### Step 5: Commit Changes
+#### Step 4: Commit Changes
 
 ```bash
 # Stage new files
@@ -240,7 +215,6 @@ git commit -m "chore: migrate to independent spec-driven development system
 
 - Install claude-sdd v1.0.0 in compatibility mode
 - Existing .kiro/specs/ paths preserved
-- CLAUDE.md simplified with reference to skill documentation
 "
 ```
 
@@ -325,17 +299,11 @@ cp -r "$OLD_SPEC" "$NEW_SPEC"
 rm -rf "$OLD_SPEC"
 ```
 
-#### Step 6: Update CLAUDE.md Active Specifications
+#### Step 6: Review Migration Progress
 
-```markdown
-## Active Specifications
-
-**New specs** (in .spec/):
-- `/spec:status new-feature-name`
-
-**Legacy specs** (in .kiro/specs/):
-- Use compatibility mode or migrate manually
-```
+Run `/spec:status` with no argument to list every spec under the new paths, with its
+phase and progress. Legacy specs left under `.kiro/specs/` stay reachable via
+compatibility mode until you migrate them.
 
 ---
 
@@ -395,25 +363,7 @@ for spec in .spec/*/; do
 done
 ```
 
-#### Step 5: Update CLAUDE.md
-
-**Replace**:
-```markdown
-### Paths
-- Steering: `.kiro/steering/`
-- Specs: `.kiro/specs/`
-- Commands: `.claude/commands/`
-```
-
-**With**:
-```markdown
-### Paths
-- Steering: `.spec-steering/`
-- Specs: `.spec/`
-- Commands: `.claude/commands/`
-```
-
-#### Step 6: Archive Legacy Directory
+#### Step 5: Archive Legacy Directory
 
 ```bash
 # Create archive
@@ -426,7 +376,7 @@ mv kiro-legacy-*.tar.gz ~/backups/
 rm -rf .kiro
 ```
 
-#### Step 7: Commit Full Migration
+#### Step 6: Commit Full Migration
 
 ```bash
 git add .claude .spec .spec-steering
@@ -436,7 +386,6 @@ git commit -m "feat: complete migration to independent spec system
 - Migrate all specs from .kiro/specs/ to .spec/
 - Migrate steering docs from .kiro/steering/ to .spec-steering/
 - Install claude-sdd v1.0.0
-- Update CLAUDE.md with new paths
 - Archive legacy .kiro/ directory
 "
 ```


### PR DESCRIPTION
## 概要

claude-sdd から CLAUDE.md 連携を全面的に廃止します（v1.2.0）。

`/spec:init-issue` などを実行するたびに「このリポジトリの CLAUDE.md は保護されているため追記しません」という報告が毎回出ていました。1.1.3 で入れた保護判定は、外部ツールが CLAUDE.md を自動生成・管理しているリポジトリ（nah-ai-wine-inventory など）では毎回発火してノイズになります。

判定を賢くするのではなく、**CLAUDE.md 連携そのものを機能から外す**方針です。進行中の仕様一覧は `/spec:status`（引数なし）に一本化します。代替の書き出し先は追加していません。

## 変更内容

### コマンド

`commands/`（配布物）と `.claude/commands/spec/`（dogfooding 用）の両系統を同一内容で更新しています。

| ファイル | 削除箇所 |
|---|---|
| `init.md` | 「6. Update CLAUDE.md Reference」節を丸ごと（最終節のため繰り上げ不要） |
| `init-issue.md` | 「8. Update CLAUDE.md Reference」節。旧 9 → 8 に繰り上げ |
| `complete.md` | 6 箇所（冒頭の説明文 / dry-run 判定ブロック / 保護判定 + awk によるエントリ削除処理 / 完了サマリーの変更ファイル一覧 / 推奨コミットメッセージ / Error Handling） |
| `status.md` | 説明文の CLAUDE.md 言及のみ。「`$SPECS_DIR` 外へ書き出す方式を復活させない」というガードレール自体は維持 |

### ドキュメント

- `README.md`: 3 箇所削除
- `docs/migration-guide.md`: CLAUDE.md 手順を含む Step を削除し、Option A/B/C の Step 番号を繰り上げ。Option B の Step 6 のみ、削除すると節が空になるため `/spec:status` を案内する説明に置き換え
- `README.ja.md`: CLAUDE.md の言及がゼロだったため変更なし

### バージョン

`plugin.json` / `marketplace.json` ともに 1.2.0。CHANGELOG に `### Removed` エントリを追加しました。

## レビューで見てほしい判断

1. **`marketplace.json` の version が 1.1.4 のまま `plugin.json`（1.1.5）と乖離していた** ため、明らかな更新漏れと判断して両方 1.2.0 に揃えました
2. **`README.md` の `/spec:steering-custom` に「CLAUDE.md に登録する」という記述がありましたが、コマンド本体に該当処理は存在しません**。古い記述と判断して削除しています

## 残存する CLAUDE.md 参照（意図的）

- `CHANGELOG.md` の 1.1.3 履歴エントリ — 当時の事実の記録なので改変しません
- `.gitignore` の `CLAUDE.md` 行 — このリポジトリ自身のローカル運用で、プラグイン機能とは無関係

## 検証

- 大文字小文字を区別した全リポジトリ走査（`grep -rn 'CLAUDE\.md\|CLAUDE_MANAGED'`）で、上記 2 つ以外ゼロヒット
- `complete.md` の bash ブロック 8 つすべてが `bash -n` を通過（大きなブロック削除で `if`/`fi` が壊れていないことを確認）
- `commands/` と `.claude/commands/spec/` が byte-identical であることを確認

## マージ後

プラグインキャッシュの更新が必要です（`/plugin` から更新、またはキャッシュ再取得）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
